### PR TITLE
Add oneshot mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ npm start
 - `NB_SPEEDTEST_RETRY_INTERVAL`: Delay between retries after failures (default: 15 minutes)
 - After reaching the maximum retry count, the script will exit with code 1
 
+**Oneshot Mode:** Set `NB_SPEEDTEST_INTERVAL=0` to run the speedtest once and exit (exit code 0 on success).
+
 **Important:** When running in Docker, use restart policies like `restart: unless-stopped` in docker-compose.yml, or use a service manager like systemd to automatically restart the process after it exits due to consecutive failures.
 
 ## Local Result Storage

--- a/index.js
+++ b/index.js
@@ -134,6 +134,11 @@ while (errorCount < retryCount) {
 		console.log(`[${new Date().toISOString()}] Finished successfully`)
 		errorCount = 0
 
+		if (testIntervalSec === 0) {
+			console.log(`[${new Date().toISOString()}] Oneshot mode (interval=0). Exiting.`)
+			process.exit(0)
+		}
+
 		const restartIn = Math.max(retryIntervalSec, 30)
 		console.log(`[${new Date().toISOString()}] Restarting in ${restartIn} sec`)
 		await delay(Math.max(testIntervalSec, 30) * 1000)


### PR DESCRIPTION
By setting NB_SPEEDTEST_INTERVAL to 0, the speedtest will only run once.